### PR TITLE
Update ffmpeg.js

### DIFF
--- a/src/ffmpeg.js
+++ b/src/ffmpeg.js
@@ -321,7 +321,7 @@ class FFMPEG extends events.EventEmitter {
         ffmpegArgs.push(`-metadata`,
                         `service_provider="dizqueTV"`,
                         `-metadata`,
-                        `service_name="${this.channel.name}`,
+                        `service_name="${this.channel.name}"`,
                         `-f`, `mpegts`);
 
         //t should be before output


### PR DESCRIPTION
missing quote after show name for FFMPEG

Found it trying to troubleshoot my ffmpeg not working.  Even with the fix, it doesn't seem to fix my problem.  You may end up having trouble with shows that have quotes in them.

Even with ffpeg logging enabled, it isn't verbose enough to actually troubleshoot.