### PR TITLE
genre support for movies

### DIFF
--- a/web/directives/plex-library.js
+++ b/web/directives/plex-library.js
@@ -66,7 +66,7 @@ module.exports = function (plex, dizquetv, $timeout) {
               try {
                 for (let i = 0; i < library.nested.length; i++) {
                     //await scope.selectItem( library.nested[i] );
-                    if (library.nested[i].type !== 'collection') {
+                    if (library.nested[i].type !== 'collection' && library.nested[i].type !== 'genre') {
                         await scope.selectShow( library.nested[i] );
                     }
                     scope.pending -= 1;

--- a/web/directives/plex-library.js
+++ b/web/directives/plex-library.js
@@ -104,7 +104,7 @@ module.exports = function (plex, dizquetv, $timeout) {
             }
             scope.fillNestedIfNecessary = async (x, isLibrary) => {
                 if ( (typeof(x.nested) === 'undefined') && (x.type !== 'collection') ) {
-                    x.nested = await plex.getNested(scope.plexServer, x.key, isLibrary, scope.errors);
+                    x.nested = await plex.getNested(scope.plexServer, x, isLibrary, scope.errors);
                 }
             }
             scope.getNested = (list, isLibrary) => {

--- a/web/public/templates/plex-library.html
+++ b/web/public/templates/plex-library.html
@@ -57,7 +57,7 @@
                                         <span ng-if="b.type === 'playlist'" class="flex-pull-right" ng-click="$event.stopPropagation(); selectPlaylist(b);">
                                             <span class="fa fa-plus btn"></span>
                                         </span>
-                                        <span ng-if="b.type === 'show' || b.type === 'collection'" class="flex-pull-right" ng-click="$event.stopPropagation(); selectShow(b);">
+                                        <span ng-if="b.type === 'show' || b.type === 'collection' || b.type === 'genre'" class="flex-pull-right" ng-click="$event.stopPropagation(); selectShow(b);">
                                             <span class="fa fa-plus btn"></span>
                                         </span>
                                     </div>

--- a/web/services/plex.js
+++ b/web/services/plex.js
@@ -84,13 +84,29 @@ module.exports = function ($http, $window, $interval) {
             const res = await client.Get('/library/sections')
             var sections = []
             for (let i = 0, l = typeof res.Directory !== 'undefined' ? res.Directory.length : 0; i < l; i++)
-                if (res.Directory[i].type === 'movie' || res.Directory[i].type === 'show')
+                if (res.Directory[i].type === 'movie' || res.Directory[i].type === 'show') {
+                    var genres = []
+                    if (res.Directory[i].type === 'movie') {
+                        const genresRes = await client.Get(`/library/sections/${res.Directory[i].key}/genre`)
+                        for (let q = 0, k = typeof genresRes.Directory !== 'undefined' ? genresRes.Directory.length : 0; q < k; q++) {
+                            if (genresRes.Directory[q].type === 'genre') {
+                                genres.push({
+                                    title: 'Genre: ' + genresRes.Directory[q].title,
+                                    key: genresRes.Directory[q].fastKey,
+                                    type: 'genre'
+                                })
+                            }
+                        }
+                    }
+
                     sections.push({
                         title: res.Directory[i].title,
                         key: `/library/sections/${res.Directory[i].key}/all`,
                         icon: `${server.uri}${res.Directory[i].composite}?X-Plex-Token=${server.accessToken}`,
-                        type: res.Directory[i].type
+                        type: res.Directory[i].type,
+                        genres: genres
                     })
+                }
             return sections
         },
         getPlaylists: async (server) => {
@@ -119,10 +135,14 @@ module.exports = function ($http, $window, $interval) {
                 return streams
             })
         },
-        getNested: async (server, key, includeCollections, errors) => {
+        getNested: async (server, lib, includeCollections, errors) => {
             var client = new Plex(server)
+            const key = lib.key
             const res = await client.Get(key)
             var nested = []
+            if (typeof (lib.genres) !== 'undefined') {
+                nested = Array.from(lib.genres)
+            }
             var seenFiles = {};
             var collections = {};
             for (let i = 0, l = typeof res.Metadata !== 'undefined' ? res.Metadata.length : 0; i < l; i++) {
@@ -226,7 +246,7 @@ module.exports = function ($http, $window, $interval) {
                         let shows = collection.nested;
                         let collectionContents = [];
                         for (let i = 0; i < shows.length; i++) {
-                            let seasons = await exported.getNested(server, shows[i].key, false);
+                            let seasons = await exported.getNested(server, shows[i], false);
                             for (let j = 0; j < seasons.length; j++) {
                                 seasons[j].title = shows[i].title + " - " + seasons[j].title;
                                 collectionContents.push(seasons[j]);


### PR DESCRIPTION
I added this locally to make it faster for me to build channels, but figured I might as well put up a PR if you are interested.
I took a look at how you added collection support for movies and tried something similar for genres.

![Screen Shot 2020-08-16 at 12 18 31 PM](https://user-images.githubusercontent.com/958167/90342139-bb72de80-dfba-11ea-8d37-46cc62c51e38.png)
![Screen Shot 2020-08-16 at 12 18 54 PM](https://user-images.githubusercontent.com/958167/90342137-b9a91b00-dfba-11ea-8549-b5f8ee169abd.png)

Genres for TV shows are also supported by plex but the UI did not support that extra level of nesting, which is why its explicitly only added for movies. I also had an earlier version that put Genre's as a top element like Playlists, but ended up here.

Long story short, feel free to reject if this is not something you think is needed. 