### PR TITLE
Fix #123. Deal with channel limits. Channel numbers 0-9999 allowed now

### DIFF
--- a/web/controllers/channels.js
+++ b/web/controllers/channels.js
@@ -39,13 +39,13 @@ module.exports = function ($scope, dizquetv) {
         }
     }
     $scope.onChannelConfigDone = async (channel) => {
-        $scope.showChannelConfig = false
         if ($scope.selectedChannelIndex != -1) {
             $scope.channels[ $scope.selectedChannelIndex ].pending = false;
         }
         if (typeof channel !== 'undefined') {
             if ($scope.selectedChannelIndex == -1) { // add new channel
                 await dizquetv.addChannel(channel);
+                $scope.showChannelConfig = false
                 $scope.refreshChannels();
             
             } else if (
@@ -56,14 +56,18 @@ module.exports = function ($scope, dizquetv) {
                 $scope.channels[ $scope.selectedChannelIndex ].pending = true;
                 await dizquetv.updateChannel(channel),
                 await dizquetv.removeChannel( { number: $scope.originalChannelNumber } )
+                $scope.showChannelConfig = false
                 $scope.$apply();
                 $scope.refreshChannels();
             } else { // update existing channel
                 $scope.channels[ $scope.selectedChannelIndex ].pending = true;
                 await dizquetv.updateChannel(channel);
+                $scope.showChannelConfig = false
                 $scope.$apply();
                 $scope.refreshChannels();
             }
+        } else {
+            $scope.showChannelConfig = false
         }
 
         

--- a/web/directives/channel-config.js
+++ b/web/directives/channel-config.js
@@ -10,11 +10,14 @@ module.exports = function ($timeout, $location, dizquetv) {
             onDone: "=onDone"
         },
         link: function (scope, element, attrs) {
+            scope.maxSize = 50000;
+    
             scope.hasFlex = false;
             scope.showHelp = false;
             scope._frequencyModified = false;
             scope._frequencyMessage = "";
             scope.minProgramIndex = 0;
+            scope.libraryLimit =  50000;
             scope.episodeMemory = {
                 saved : false,
             };
@@ -95,6 +98,7 @@ module.exports = function ($timeout, $location, dizquetv) {
                 updateChannelDuration();
                 setTimeout( () => { scope.showRotatedNote = true }, 1, 'funky');
             }
+
             scope._selectedRedirect = {
                 isOffline : true,
                 type : "redirect",
@@ -1038,12 +1042,15 @@ module.exports = function ($timeout, $location, dizquetv) {
                         scope.hasFlex = true;
                     }
                 }
+                scope.maxSize = Math.max(scope.maxSize, scope.channel.programs.length);
+                scope.libraryLimit = Math.max(0, scope.maxSize - scope.channel.programs.length );
             }
             scope.error = {}
-            scope._onDone = (channel) => {
-                if (typeof channel === 'undefined')
-                    scope.onDone()
-                else {
+            scope._onDone = async (channel) => {
+                if (typeof channel === 'undefined') {
+                    await scope.onDone()
+                    $timeout();
+                } else {
                     channelNumbers = []
                     for (let i = 0, l = scope.channels.length; i < l; i++)
                         channelNumbers.push(scope.channels[i].number)
@@ -1056,8 +1063,8 @@ module.exports = function ($timeout, $location, dizquetv) {
                         scope.error.number = "Channel number already in use."
                     else if (!scope.isNewChannel && channel.number !== scope.beforeEditChannelNumber && channelNumbers.indexOf(parseInt(channel.number, 10)) !== -1)
                         scope.error.number = "Channel number already in use."
-                    else if (channel.number <= 0 || channel.number >= 2000)
-                        scope.error.name = "Enter a valid number (1-2000)"
+                    else if (channel.number < 0 || channel.number > 9999)
+                        scope.error.name = "Enter a valid number (0-9999)"
                     else if (typeof channel.name === "undefined" || channel.name === null || channel.name === "")
                         scope.error.name = "Enter a channel name."
                     else if (channel.icon !== "" && !validURL(channel.icon))
@@ -1073,7 +1080,21 @@ module.exports = function ($timeout, $location, dizquetv) {
                         for (let i = 0; i < scope.channel.programs.length; i++) {
                             delete scope.channel.programs[i].$index;
                         }
-                        scope.onDone(JSON.parse(angular.toJson(channel)))
+                        try {
+                            let s = angular.toJson(channel);
+                            if (s.length > 50*1000*1000) {
+                                scope.error.any = true;
+                                scope.error.programs = "Channel is too large, can't save.";
+                            } else {
+                                await scope.onDone(JSON.parse(s))
+                                s = null;
+                            }
+                        } catch(err) {
+                            $timeout();
+                            console.error(err);
+                            scope.error.any = true;
+                            scope.error.programs = "Unable to save channel."
+                        }
                     }
                     $timeout(() => { scope.error = {} }, 60000)
                 }
@@ -1132,7 +1153,7 @@ module.exports = function ($timeout, $location, dizquetv) {
                 if (scope.channel.programs.length == 0) {
                     return 1;
                 } else {
-                    return Math.floor( 50000 / scope.channel.programs.length );
+                    return Math.floor( scope.maxSize / (scope.channel.programs.length) );
                 }
             }
             scope.removeItem = (x) => {
@@ -1165,6 +1186,9 @@ module.exports = function ($timeout, $location, dizquetv) {
             };
             scope.loadChannels();
 
+            scope.disablePadding = () => {
+                return (scope.paddingOption.id==-1) || (2*scope.channel.programs.length > scope.maxSize);
+            }
             scope.paddingOptions = [
                 { id: -1, description: "Allowed start times", allow5: false },
                 { id: 30, description: ":00, :30", allow5: false },
@@ -1178,6 +1202,14 @@ module.exports = function ($timeout, $location, dizquetv) {
 
             ]
             scope.paddingOption  = scope.paddingOptions[0];
+
+            scope.breaksDisabled = () => {
+                return scope.breakAfter==-1
+                    || scope.minBreakSize==-1 || scope.maxBreakSize==-1
+                    || (scope.minBreakSize > scope.maxBreakSize)
+                    || (2*scope.channel.programs.length > scope.maxSize);
+            }
+
             scope.breakAfterOptions = [
                 { id: -1, description: "After" },
                 { id: 5, description: "5 minutes" },
@@ -1229,6 +1261,11 @@ module.exports = function ($timeout, $location, dizquetv) {
                 { id: 3, description: "3" },
                 { id: 4, description: "4" },
             ];
+            scope.rerunsDisabled = () => {
+                return scope.rerunStart == -1 || scope.rerunBlockSize == -1 || scope.rerunRepeats == -1
+                   || (scope.channel.programs.length * scope.rerunRepeats > scope.maxSize)
+
+            }
 
 
             scope.nightStartHours = [ { id: -1, description: "Start" } ];

--- a/web/directives/plex-library.js
+++ b/web/directives/plex-library.js
@@ -7,7 +7,7 @@ module.exports = function (plex, dizquetv, $timeout) {
             onFinish: "=onFinish",
             height: "=height",
             visible: "=visible",
-            limit: "@limit",
+            limit: "=limit",
         },
         link: function (scope, element, attrs) {
             scope.errors=[];

--- a/web/public/templates/channel-config.html
+++ b/web/public/templates/channel-config.html
@@ -152,20 +152,20 @@
                                 <p>The channel's regular programming between the specified hours. Flex time will fill up the remaining hours.</p>
 
                                 <h6>Pad Times</h6>
-                                <p>Adds Flex breaks after each TV episode or movie to ensure that the program starts at one of the allowed minute marks. For example, you can use this to ensure that all your programs start at either XX:00 times or XX:30 times. Removes any existing Flex periods before adding the new ones.</p>
+                                <p>Adds Flex breaks after each TV episode or movie to ensure that the program starts at one of the allowed minute marks. For example, you can use this to ensure that all your programs start at either XX:00 times or XX:30 times. Removes any existing Flex periods before adding the new ones. This button might be disabled if the channel is already too large.</p>
 
                                 <h6>Add Breaks</h6>
-                                <p>Adds Flex breaks between programs, attempting to avoid groups of consecutive programs that exceed the specified number of minutes.</p>
+                                <p>Adds Flex breaks between programs, attempting to avoid groups of consecutive programs that exceed the specified number of minutes. This button might be disabled if the channel is already too large.</p>
 
                                 <h6>Reruns</h6>
-                                <p>Divides the programming in blocks of 6, 8 or 12 hours then repeats each of the blocks the specified number of times. For example,  you can make a channel that plays exactly the same channels in the morning and in the afternoon. </p>
+                                <p>Divides the programming in blocks of 6, 8 or 12 hours then repeats each of the blocks the specified number of times. For example,  you can make a channel that plays exactly the same channels in the morning and in the afternoon. This button might be disabled if the channel is already too large.</p>
 
                                 <h6>Save|Recover Episode Positions</h6>
                                 <p>The &quot;Save&quot; button saves the current episodes that are next to be played for each tv show. Then whenever you click the &quot;Recover Episode Popsitions&quot; button, episodes will be rearranged cyclically and they will start with the saved positions. So you can maintain episode sequences even after modifying the channel. If there are any new TV shows, they will start at their current positions. Movies and specials won&apos;t change positions.
                                 </p>
 
                                 <h6>Replicate</h6>
-                                <p>Makes multiple copies of the schedule and plays them in sequence. Normally this isn&apos;t necessary, because dizqueTV will always play the schedule back from the beginning when it finishes. But creating replicas is a useful intermediary step sometimes before applying other transformations. Note that because very large channels can be problematic, there&apos;s a limit of 50000 programs to the size of the resulting channel when using this tool.</p>
+                                <p>Makes multiple copies of the schedule and plays them in sequence. Normally this isn&apos;t necessary, because dizqueTV will always play the schedule back from the beginning when it finishes. But creating replicas is a useful intermediary step sometimes before applying other transformations. Note that because very large channels can be problematic, the number of replicas will be limited to avoid creating really large channels.</p>
 
                                 <h6>Replicate &amp; Shuffle</h6>
                                 <p>Like &quot;Replicate&quot;, it will make multiple copies of the programming. In addition it will shuffle the programs, but it will make sure not to have too small a distance between two identical programs.</p>
@@ -282,7 +282,7 @@
                                             ng-options="o as o.description for o in paddingOptions" />
 
                                         </div>
-                                        <button ng-disabled="paddingOption.id==-1" class="btn btn-sm btn-warning form-control form-control-sm" type="button" ng-click="padTimes(paddingOption.id, paddingOption.allow5)">
+                                        <button ng-disabled="disablePadding()" class="btn btn-sm btn-warning form-control form-control-sm" type="button" ng-click="padTimes(paddingOption.id, paddingOption.allow5)">
                                             <i class='far fa-clock'></i> Pad Times
                                         </button>
                                     </div>
@@ -298,7 +298,7 @@
                                             <select style="width:5em" ng-model="maxBreakSize"
                                             ng-options="o.id as o.description for o in maxBreakSizeOptions" />
                                         </div>
-                                        <button class="btn btn-sm btn-warning form-control form-control-sm" type="button" ng-click="addBreaks(breakAfter, minBreakSize, maxBreakSize)" ng-disabled="breakAfter==-1 || minBreakSize==-1 || maxBreakSize==-1 || (minBreakSize > maxBreakSize)">
+                                        <button class="btn btn-sm btn-warning form-control form-control-sm" type="button" ng-click="addBreaks(breakAfter, minBreakSize, maxBreakSize)" ng-disabled="breaksDisabled()">
                                             <i class='fa fa-coffee'></i> Add Breaks
                                         </button>
                                     </div>
@@ -318,7 +318,7 @@
                                         ng-options="o.id as o.description for o in rerunRepeatOptions">
                                         </select>
                                     </div>
-                                    <button class="btn btn-sm btn-warning form-control form-control-sm" type="button" ng-click="doReruns(rerunStart, rerunBlockSize, rerunRepeats)" ng-disabled="rerunStart == -1 || rerunBlockSize == -1 || rerunRepeats == -1" >
+                                    <button class="btn btn-sm btn-warning form-control form-control-sm" type="button" ng-click="doReruns(rerunStart, rerunBlockSize, rerunRepeats)" ng-disabled="rerunsDisabled()" >
                                         <i class='far fa-clone'></i> Reruns
                                     </button>
                                 </div>
@@ -489,6 +489,6 @@
     <frequency-tweak programs="_programFrequencies" message="_frequencyMessage" modified="_frequencyModified" on-done="tweakFrequencies"></frequency-tweak>
     <remove-shows program-titles="_removablePrograms" on-done="removeShows" deleted="_deletedProgramNames"></remove-shows>
     <offline-config offline-title="Add Flex Time" program="_addingOffline" on-done="finishedAddingOffline"></offline-config>
-    <plex-library height="300" visible="displayPlexLibrary" on-finish="importPrograms"></plex-library>
+    <plex-library limit="libraryLimit" height="300" visible="displayPlexLibrary" on-finish="importPrograms"></plex-library>
     <channel-redirect visible="_displayRedirect" on-done="finishRedirect" form-title="_redirectTitle" program="_selectedRedirect" ></channel-redirect>
 </div>

--- a/web/public/templates/offline-config.html
+++ b/web/public/templates/offline-config.html
@@ -165,6 +165,6 @@
             </div>
         </div>
     </div>
-    <plex-library height="300" visible="showPlexLibrary" on-finish="importPrograms"></plex-library>
+    <plex-library limit=1000000000 height="300" visible="showPlexLibrary" on-finish="importPrograms"></plex-library>
     <plex-library height="300" limit=1 visible="showFallbackPlexLibrary" on-finish="importFallback"></plex-library>
 </div>


### PR DESCRIPTION
### Explanation of the changes, problem that they are intended to fix.

Things in the channel editor now have protections against generating very big channels. There's now an explicit programs limit of 50000. If the channel is already larger than 50000, its current size will be used as a limit. The editor will also make sure to disable some tool buttons when they would definitely allow surpassing the limit. And the library importer itself will keep the limit in mind. In the case the UI still managed to generate a channel that's too large (in bytes) for the api to handle, the error will be detected and the channel window will not allow saving it.

This limit will be configurable in a later version. But note that we are not allowed to add unstable features like that in 1.0.x

...

### All Submissions:

* [X] I have read the code of conduct.
* [X] I am submitting to the correct base branch

   * Bug fixes must go to `dev/1.0.x`.
   * New features must go to `dev/1.1.x`.
