### PR TITLE
Option  to limit the framerate of dizqueTV's output

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -303,6 +303,10 @@ function api(db, channelDB, fillerDB, xmltvInterval,  guideService ) {
       try {
         db['ffmpeg-settings'].update({ _id: req.body._id }, req.body)
         let ffmpeg = db['ffmpeg-settings'].find()[0]
+        let err = fixupFFMPEGSettings(ffmpeg);
+        if (typeof(err) !== 'undefined') {
+          return res.status(400).send(err);
+        }
         res.send(ffmpeg)
       } catch(err) {
         console.error(err);
@@ -322,6 +326,14 @@ function api(db, channelDB, fillerDB, xmltvInterval,  guideService ) {
       }
 
     })
+
+    function fixupFFMPEGSettings(ffmpeg) {
+      if (typeof(ffmpeg.maxFPS) === 'undefined') {
+        ffmpeg.maxFPS = 60;
+      } else if ( isNaN(ffmpeg.maxFPS) ) {
+        return "maxFPS should be a number";
+      }
+    }
 
     // PLEX SETTINGS
     router.get('/api/plex-settings', (req, res) => {

--- a/src/database-migration.js
+++ b/src/database-migration.js
@@ -20,7 +20,7 @@
 const path = require('path');
 var fs = require('fs');
 
-const TARGET_VERSION = 600;
+const TARGET_VERSION = 601;
 
 const STEPS = [
     // [v, v2, x] : if the current version is v, call x(db), and version becomes v2
@@ -31,6 +31,7 @@ const STEPS = [
     [    400,    500, (db,channels) => splitServersSingleChannels(db, channels) ],
     [    500,    501, (db) => fixCorruptedServer(db) ],
     [    501,    600, () => extractFillersFromChannels() ],
+    [    600,    601, (db) => addFPS(db) ],
 ]
 
 const { v4: uuidv4 } = require('uuid');
@@ -392,6 +393,7 @@ function ffmpeg() {
         normalizeAudioCodec: true,
         normalizeResolution: true,
         normalizeAudio: true,
+        maxFPS: 60,
     }
 }
 
@@ -660,6 +662,13 @@ function extractFillersFromChannels() {
     }
     console.log("Done extracting fillers from channels.");
    
+}
+
+function addFPS(db) {
+    let ffmpegSettings = db['ffmpeg-settings'].find()[0];
+    let f = path.join(process.env.DATABASE, 'ffmpeg-settings.json');
+    ffmpegSettings.maxFPS = 60;
+    fs.writeFileSync( f, JSON.stringify( [ffmpegSettings] ) );
 }
 
 module.exports = {

--- a/web/directives/ffmpeg-settings.js
+++ b/web/directives/ffmpeg-settings.js
@@ -59,6 +59,17 @@
                 {value:"sine", description:"Beep"},
                 {value:"silent", description:"No Audio"},
             ]
+            scope.fpsOptions = [
+                {id: 23.976, description: "23.976 frames per second"},
+                {id: 24, description: "24 frames per second"},
+                {id: 25, description: "25 frames per second"},
+                {id: 29.97, description: "29.97 frames per second"},
+                {id: 30, description: "30 frames per second"},
+                {id: 50, description: "50 frames per second"},
+                {id: 59.94, description: "59.94 frames per second"},
+                {id: 60, description: "60 frames per second"},
+                {id: 120, description: "120 frames per second"},
+            ];
         }
     }
 }

--- a/web/public/templates/ffmpeg-settings.html
+++ b/web/public/templates/ffmpeg-settings.html
@@ -91,6 +91,10 @@
             <br />
             <label>Video Buffer Size (k)</label>
             <input type="number" class="form-control form-control-sm" ng-model="settings.videoBufSize"/>
+            <label>Max Frame Rate</label>
+            <select class='form-control custom-select'  ng-model="settings.maxFPS" ria-describedby="fpsHelp"
+            ng-options="o.id as o.description for o in fpsOptions" ></select>
+            <small id='fpsHelp' class='form-text text-muted'>Will transcode videos that have FPS higher than this.</small>
         </div>
 
         <div class="form-group">


### PR DESCRIPTION
### Explanation of the changes, problem that they are intended to fix.

Tivimate seems to break massively when the fps is higher than 30. At least in my TV. So this new option helps in those use cases. Also if we are honest, 60 fps is more of a thing in video games and stuff. For TV we usually have 30 fps or lower. 

...

### All Submissions:

* [X] I have read the code of conduct.
* [X] I am submitting to the correct base branch
<!--
   * Bug fixes must go to `dev/1.1.x`.
   * New features must go to `dev/1.2.x`.
-->
### Changes that modify the db structure

* [X] Backwards compatibility: Users running the new code using an existing .disquetv folder will not lose their channels / settings.
* [X] I've implemented the necessary db migration steps if any.

### New features

* [X] I understand that the feature may not be accepted if it doesn't fit the upstream app's planned design direction. But that in this case I am encouraged to share this as an available modification other users can use if they want.

