### PR TITLE
Improvements on Add Plex Server UX and fixed 'of null' common errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "angular": "^1.7.9",
     "angular-router-browserify": "0.0.2",
     "angular-vs-repeat": "2.0.13",
-    "random-js" : "2.1.0",
+    "random-js": "2.1.0",
     "axios": "^0.19.2",
     "body-parser": "^1.19.0",
     "diskdb": "^0.1.17",
@@ -27,7 +27,7 @@
     "node-ssdp": "^4.0.0",
     "request": "^2.88.2",
     "uuid": "^8.0.0",
-    "node-graceful-shutdown" : "1.1.0",
+    "node-graceful-shutdown": "1.1.0",
     "xml-writer": "^1.7.0"
   },
   "bin": "dist/index.js",
@@ -41,7 +41,7 @@
     "del-cli": "^3.0.0",
     "nodemon": "^2.0.3",
     "watchify": "^3.11.1",
-    "nexe" : "^3.3.7"
+    "nexe": "^3.3.7"
   },
   "babel": {
     "plugins": [

--- a/web/directives/plex-settings.js
+++ b/web/directives/plex-settings.js
@@ -18,14 +18,16 @@ module.exports = function (plex, dizquetv, $timeout) {
                 let servers = await dizquetv.getPlexServers();
                 scope.serversPending = false;
                 scope.servers = servers;
-                for (let i = 0; i < scope.servers.length; i++) {
-                    scope.servers[i].uiStatus = 0;
-                    scope.servers[i].backendStatus = 0;
-                    let t = (new Date()).getTime();
-                    scope.servers[i].uiPending = t;
-                    scope.servers[i].backendPending = t;
-                    scope.refreshUIStatus(t, i);
-                    scope.refreshBackendStatus(t, i);
+                if(servers) {
+                    for (let i = 0; i < scope.servers.length; i++) {
+                        scope.servers[i].uiStatus = 0;
+                        scope.servers[i].backendStatus = 0;
+                        let t = (new Date()).getTime();
+                        scope.servers[i].uiPending = t;
+                        scope.servers[i].backendPending = t;
+                        scope.refreshUIStatus(t, i);
+                        scope.refreshBackendStatus(t, i);
+                    }
                 }
                 setTimeout( () => { scope.$apply() }, 31000 );
                 scope.$apply();
@@ -51,13 +53,15 @@ module.exports = function (plex, dizquetv, $timeout) {
 
             scope.isAnyUIBad = () => {
                 let t = (new Date()).getTime();
-                for (let i = 0; i < scope.servers.length; i++) {
-                    let s = scope.servers[i];
-                    if (
-                        (s.uiStatus == -1)
-                        || ( (s.uiStatus == 0) && (s.uiPending + 30000 < t) )
-                    ) {
-                        return true;
+                if(scope.servers) {
+                    for (let i = 0; i < scope.servers.length; i++) {
+                        let s = scope.servers[i];
+                        if (
+                            (s.uiStatus == -1)
+                            || ( (s.uiStatus == 0) && (s.uiPending + 30000 < t) )
+                        ) {
+                            return true;
+                        }
                     }
                 }
                 return false;
@@ -65,13 +69,15 @@ module.exports = function (plex, dizquetv, $timeout) {
 
             scope.isAnyBackendBad = () => {
                 let t = (new Date()).getTime();
-                for (let i = 0; i < scope.servers.length; i++) {
-                    let s = scope.servers[i];
-                    if (
-                        (s.backendStatus == -1)
-                        || ( (s.backendStatus == 0) && (s.backendPending + 30000 < t) )
-                    ) {
-                        return true;
+                if(scope.servers) {
+                    for (let i = 0; i < scope.servers.length; i++) {
+                        let s = scope.servers[i];
+                        if (
+                            (s.backendStatus == -1)
+                            || ( (s.backendStatus == 0) && (s.backendPending + 30000 < t) )
+                        ) {
+                            return true;
+                        }
                     }
                 }
                 return false;
@@ -146,7 +152,7 @@ module.exports = function (plex, dizquetv, $timeout) {
             }
 
             scope.shouldDisableSubtitles = () => {
-                return scope.settings.forceDirectPlay || (scope.settings.streamPath === "direct" );
+                return scope.settings && (scope.settings.forceDirectPlay || (scope.settings.streamPath === "direct" ));
             }
 
             scope.addPlexServer = async () => {
@@ -216,10 +222,10 @@ module.exports = function (plex, dizquetv, $timeout) {
                 {id:"direct",description:"Direct"}
             ];
             scope.hideIfNotPlexPath = () => {
-                return scope.settings.streamPath != 'plex'
+                return scope.settings && scope.settings.streamPath != 'plex'
             };
             scope.hideIfNotDirectPath = () => {
-                return scope.settings.streamPath != 'direct'
+                return scope.settings && scope.settings.streamPath != 'direct'
             };
             scope.maxAudioChannelsOptions=[
                 {id:"1",description:"1.0"},


### PR DESCRIPTION
### Explanation of the changes, problem that they are intended to fix.

I offer a fix for 3 situations:
- A Simple improvement to "Add Server" functionality. Before when you click to "Sign In/Add Servers", a new window/tab is open, when you accept plex authorization, this window not closes and user not get a visual feedback. Now, a new window is open like a popup, staying the dizquetv site on the background, and after authorization this modal is closed.
- Added some simple `if` logics to prevents common `of null` errors. These errors are showed when you don't have Plex servers.
- Removed spaces unnecessary on package.json. The `npm install` do this automatically.

### All Submissions:

* [x] I have read the code of conduct.
* [x] I am submitting to the correct base branch

### New features

* [x] I understand that the feature may not be accepted if it doesn't fit the upstream app's planned design direction. But that in this case I am encouraged to share this as an available modification other users can use if they want.
