### PR TITLE
add ffmpeg deinterlace options

### DIFF
--- a/src/database-migration.js
+++ b/src/database-migration.js
@@ -20,7 +20,7 @@
 const path = require('path');
 var fs = require('fs');
 
-const TARGET_VERSION = 701;
+const TARGET_VERSION = 702;
 
 const STEPS = [
     // [v, v2, x] : if the current version is v, call x(db), and version becomes v2
@@ -34,6 +34,7 @@ const STEPS = [
     [    600,    601, (db) => addFPS(db) ],
     [    601,    700, (db) => migrateWatermark(db) ],
     [    700,    701, (db) => addScalingAlgorithm(db) ],
+    [    701,    702, (db) => addDeinterlaceFilter(db) ]
 ]
 
 const { v4: uuidv4 } = require('uuid');
@@ -397,6 +398,7 @@ function ffmpeg() {
         normalizeAudio: true,
         maxFPS: 60,
         scalingAlgorithm: "bicubic",
+        deinterlaceFilter: "none"
     }
 }
 
@@ -755,6 +757,12 @@ function addScalingAlgorithm(db) {
     fs.writeFileSync( f, JSON.stringify( [ffmpegSettings] ) );
 }
 
+function addDeinterlaceFilter(db) {
+    let ffmpegSettings = db['ffmpeg-settings'].find()[0];
+    let f = path.join(process.env.DATABASE, 'ffmpeg-settings.json');
+    ffmpegSettings.deinterlaceFilter = "none";
+    fs.writeFileSync( f, JSON.stringify( [ffmpegSettings] ) );
+}
 
 module.exports = {
     initDB: initDB,

--- a/src/ffmpeg.js
+++ b/src/ffmpeg.js
@@ -165,6 +165,12 @@ class FFMPEG extends events.EventEmitter {
                 currentVideo ="[fpchange]";
             }
 
+            // deinterlace if desired
+            if (streamStats.videoScanType == 'interlaced' && this.opts.deinterlaceFilter != 'none') {
+                videoComplex += `;${currentVideo}${this.opts.deinterlaceFilter}[deinterlaced]`;
+                currentVideo = "[deinterlaced]";
+            }
+
             // prepare input streams
             if ( typeof(streamUrl.errorTitle) !== 'undefined') {
                 doOverlay = false; //never show icon in the error screen

--- a/src/plexTranscoder.js
+++ b/src/plexTranscoder.js
@@ -236,6 +236,7 @@ lang=en`
                     // Rounding framerate avoids scenarios where
                     // 29.9999999 & 30 don't match.
                     ret.videoDecision = (typeof stream.decision === 'undefined') ? 'copy' : stream.decision;
+                    ret.videoScanType = stream.scanType;
                 }
                 // Audio. Only look at stream being used
                 if (stream["streamType"] == "2" && stream["selected"] == "1") {

--- a/web/directives/ffmpeg-settings.js
+++ b/web/directives/ffmpeg-settings.js
@@ -66,6 +66,14 @@ module.exports = function (dizquetv, resolutionOptions) {
                 {id: "lanczos", description: "lanczos"},
                 {id: "spline", description: "spline"},
             ];
+            scope.deinterlaceOptions = [
+                {value: "none", description: "do not deinterlace"},
+                {value: "bwdif=0", description: "bwdif send frame"},
+                {value: "bwdif=1", description: "bwdif send field"},
+                {value: "w3fdif", description: "w3fdif"},
+                {value: "yadif=0", description: "yadif send frame"},
+                {value: "yadif=1", description: "yadif send field"}
+            ];
 
         }
     }

--- a/web/public/templates/ffmpeg-settings.html
+++ b/web/public/templates/ffmpeg-settings.html
@@ -103,6 +103,11 @@
             ng-options="o.id as o.description for o in scalingOptions" ></select>
             <small id='scalingHelp' class='form-text text-muted'>Scaling algorithm to use when the transcoder needs to change the video size.</small>
 
+            <br />
+            <label>Deinterlace Filter</label>
+            <select class='form-control custom-select'  ng-model="settings.deinterlaceFilter" ria-describedby="deinterlaceHelp"
+            ng-options="o.value as o.description for o in deinterlaceOptions" ></select>
+            <small id='deinterlaceHelp' class='form-text text-muted'>Deinterlace filter to use when video is interlaced. This is only needed when Plex transcoding is not used.</small>
         </div>
 
         <div class="form-group">


### PR DESCRIPTION
### Explanation of the changes, problem that they are intended to fix.

This adds deinterlace filter options to the ffmpeg transcode settings. With these settings, interlaced content can be deinterlaced when content is direct played from Plex or played from disk.

The video scan type (progressive, interlaced) is sourced from Plex and added to the stream stats. ffmpeg will then add the deinterlace filter to the complex filter chain if appropriate (stream stats indicate that content is interlaced and a filter has been selected). 

### All Submissions:

* [x] I have read the code of conduct.
* [x] I am submitting to the correct base branch
<!--
   * Bug fixes must go to `dev/1.2.x`.
   * New features must go to `dev/1.3.x`.
-->
### Changes that modify the db structure

* [x] Backwards compatibility: Users running the new code using an existing .disquetv folder will not lose their channels / settings.
* [x] I've implemented the necessary db migration steps if any.

### New features

* [x] I understand that the feature may not be accepted if it doesn't fit the upstream app's planned design direction. But that in this case I am encouraged to share this as an available modification other users can use if they want.

