### PR TITLE
Fix Metadata Undefined bug

### DIFF
--- a/web/services/plex.js
+++ b/web/services/plex.js
@@ -172,6 +172,7 @@ module.exports = function ($http, $window, $interval) {
             var client = new Plex(server)
             const key = lib.key
             const res = await client.Get(key)
+            const size = res.Metadata !== 'undefined' ? res.Metadata.length : 0;
             var nested = []
             if (typeof (lib.genres) !== 'undefined') {
                 nested = Array.from(lib.genres)
@@ -181,7 +182,7 @@ module.exports = function ($http, $window, $interval) {
 
             let albumKeys = {};
             let albums = {};
-            for (let i = 0; i < res.size; i++) {
+            for (let i = 0; i < size; i++) {
                 let meta = res.Metadata[i];
                 if (meta.type === 'track') {
                     albumKeys[ meta.parentKey ] = false;
@@ -200,7 +201,7 @@ module.exports = function ($http, $window, $interval) {
                 }
             } ) );
 
-            for (let i = 0; i < res.size; i++) {
+            for (let i = 0; i < size; i++) {
               try {
                 // Skip any videos (movie or episode) without a duration set...
                 if (typeof res.Metadata[i].duration === 'undefined' && (res.Metadata[i].type === "episode" || res.Metadata[i].type === "movie"))


### PR DESCRIPTION
### Explanation of the changes, problem that they are intended to fix.
When you try to navigate on Plex Library using `+` a undefined error are printed.

https://user-images.githubusercontent.com/4449232/105798199-5b706300-5f70-11eb-97eb-58117543f5b3.mp4

#### Solution
Just added 2 `if` to validate `res.Metadata[i]` in loops.
After line 206, all changes are only an `Tab` reindentation. And Line 297 too!

### All Submissions:

* [x] I have read the code of conduct.
* [x] I am submitting to the correct base branch
<!--
   * Bug fixes must go to `dev/1.2.x`.
   * New features must go to `dev/1.3.x`.
-->
