### PR TITLE
Improve logging around getting plex status

### DIFF
--- a/src/plexTranscoder.js
+++ b/src/plexTranscoder.js
@@ -416,8 +416,15 @@ X-Plex-Token=${this.server.accessToken}`;
     }
 
     updatePlex() {
-        this.log("Updating plex status")
-        axios.post(this.getStatusUrl());
+        this.log("Updating plex status");
+        const statusUrl = this.getStatusUrl();
+        try {
+            axios.post(statusUrl);
+        } catch (error) {
+            this.log(`Problem updating Plex status using status URL ${statusUrl}:`);
+            this.log(error);
+            return false;
+        }
         this.currTimeMs += this.updateInterval;
         if (this.currTimeMs > this.duration) {
             this.currTimeMs = this.duration;


### PR DESCRIPTION
### Explanation of the changes, problem that they are intended to fix.
This is intended to improve logging to help debug an issue I've noticed in 1.3.x.

I've been having issues in 1.3.x with certain programs being stuck on the DizqueTV loading screen.
One of these issues manifests in the logs as a mysterious 404 error appearing right after `Updating plex status`. It appears to be 404ing when attempting to post to the plex status URL. Being able to further debug this may be useful.

### All Submissions:

* [x] I have read the code of conduct.
* [x] I am submitting to the correct base branch
<!--
   * Bug fixes must go to `dev/1.2.x`.
   * New features must go to `dev/1.3.x`.
-->
