### PR TITLE
localization fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14-alpine3.14
+FROM node:12.18-alpine3.12
 WORKDIR /home/node/app
 COPY package*.json ./
 RUN npm install && npm install -g browserify nexe@3.3.7

--- a/make_dist.sh
+++ b/make_dist.sh
@@ -10,6 +10,7 @@ npm run build || exit 1
 npm run compile  || exit 1
 cp -R ./web ./dist/web
 cp -R ./resources ./dist/
+cp -R ./locales/ ./dist/locales/
 cd dist
 if [ "$MODE" == "all" ]; then
     nexe --temp /var/nexe -r "./**/*" -t windows-x64-12.18.2 --output $WIN64


### PR DESCRIPTION
### Explanation of the changes, problem that they are intended to fix.

Fix localization issues. Node version in the docker image is pointless because nexe keeps using 12. Using 14 for nexe doesn't work, so it will stay at 12 for the time being.

Fix an issue with server messages not getting localized when in docker/nexe

### All Submissions:

* [X] I have read the code of conduct.
* [X] I am submitting to the correct base branch

