### PR TITLE
Fix #350 : random slots bug

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -1053,6 +1053,19 @@ function api(db, channelDB, fillerDB, customShowDB, xmltvInterval,  guideService
         delete program.streams;
         delete program.durationStr;
         delete program.commercials;
+        if (
+          (typeof(program.duration) === 'undefined')
+          ||
+          (program.duration <= 0)
+        ) {
+          console.error(`Input contained a program with invalid duration: ${program.duration}. This program has been deleted`);
+          return [];
+        }
+        if (! Number.isInteger(program.duration) ) {
+          console.error(`Input contained a program with invalid duration: ${program.duration}. Duration got fixed to be integer.`);
+          program.duration = Math.ceil(program.duration);
+        }
+        return [ program ];
     }
 
     function cleanUpChannel(channel) {
@@ -1063,10 +1076,15 @@ function api(db, channelDB, fillerDB, customShowDB, xmltvInterval,  guideService
         ) {
           channel.groupTitle = "dizqueTV";
         }
-        channel.programs.forEach( cleanUpProgram );
+        channel.programs = channel.programs.flatMap( cleanUpProgram );
         delete channel.fillerContent;
         delete channel.filler;
-        channel.fallback.forEach( cleanUpProgram );
+        channel.fallback = channel.fallback.flatMap( cleanUpProgram );
+        channel.duration = 0;
+        for (let i = 0; i < channel.programs.length; i++) {
+          channel.duration += channel.programs[i].duration;
+        }
+
     }
 
     async function streamToolResult(toolRes, res) {

--- a/src/services/random-slots-service.js
+++ b/src/services/random-slots-service.js
@@ -405,10 +405,14 @@ module.exports = async( programs, schedule  ) => {
             }
         } else if (flexBetween) {
             //just distribute it equitatively
-            let div = rem / pads.length;
+            let div = Math.floor( rem / pads.length );
+            let totalAdded = 0;
             for (let i = 0; i < pads.length; i++) {
                 pads[i].pad += div;
+                totalAdded += div;
             }
+            pads[0].pad += rem - totalAdded;
+
         } else {
             //also add div to the latest item
             pads[ pads.length - 1].pad += rem;


### PR DESCRIPTION
### Explanation of the changes, problem that they are intended to fix.

#350 random slots no longer have a chance to generate flex time with fractional duration. API protection to protect against bad durations. Migration step to fix existing channels that were affected by the bug
...

### All Submissions:

* [X] I have read the code of conduct.
* [X] I am submitting to the correct base branch
<!--
   * Bug fixes must go to `dev/1.4.x`.
   * New features must go to `dev/1.5.x`.
-->
### Changes that modify the db structure

* [X] Backwards compatibility: Users running the new code using an existing .disquetv folder will not lose their channels / settings.
* [X] I've implemented the necessary db migration steps if any.
