### PR TITLE
Track title rather than album title in XML

### DIFF
--- a/src/services/tv-guide-service.js
+++ b/src/services/tv-guide-service.js
@@ -500,6 +500,9 @@ function makeEntry(channel, x) {
                 episode: x.program.episode,
                 title: x.program.title,
             }
+        } else if (x.program.type === 'track') {
+            title = x.program.title;
+            // TODO: Add sub data for tracks here for XML writing
         }
     }
     if (typeof(title)==='undefined') {

--- a/src/xmltv.js
+++ b/src/xmltv.js
@@ -98,6 +98,7 @@ async function _writeProgramme(channel, program, xw, xmlSettings, cacheImageServ
     xw.writeRaw('\n        <previously-shown/>')
 
     //sub-title
+    // TODO: Add support for track data (artist, album) here
     if ( typeof(program.sub) !== 'undefined') {
         xw.startElement('sub-title')
         xw.writeAttribute('lang', 'en')

--- a/web/controllers/guide.js
+++ b/web/controllers/guide.js
@@ -313,7 +313,7 @@ module.exports = function ($scope, $timeout, dizquetv) {
             ch.programs.push( {
                 duration: addDuration(b - a),
                 altTitle: altTitle,
-                showTitle: program.title,
+                showTitle: program.title,  // movie title, episode title or track title
                 subTitle: subTitle,
                 episodeTitle : episodeTitle,
                 start: hasStart,


### PR DESCRIPTION
### Explanation of the changes, problem that they are intended to fix.

- Show track title rather than album title on XML for songs

### All Submissions:

* [x] I have read the code of conduct.
* [x] I am submitting to the correct base branch
<!--
   * Bug fixes must go to `dev/1.4.x`.
   * New features must go to `dev/1.5.x`.
-->
### Changes that modify the db structure

* [x] Backwards compatibility: Users running the new code using an existing .disquetv folder will not lose their channels / settings.
* [ ] I've implemented the necessary db migration steps if any.

### New features

* [x] I understand that the feature may not be accepted if it doesn't fit the upstream app's planned design direction. But that in this case I am encouraged to share this as an available modification other users can use if they want.

