### PR TITLE
Fix original duration override bug and add start time validation

### DIFF
--- a/src/services/channel-service.js
+++ b/src/services/channel-service.js
@@ -69,9 +69,6 @@ function cleanUpProgram(program) {
         program.endPosition = parseInt(program.endPosition, 10);
     }
 
-    if (program.start && program.stop) {
-        program.duration = new Date(program.stop) - new Date(program.start);
-    }
     delete program.streams;
     delete program.durationStr;
     delete program.commercials;


### PR DESCRIPTION
### Explanation of the changes, problem that they are intended to fix.

**Fix duration override bug:** `cleanUpProgram` was recalculating `program.duration` from `start`/`stop` times, overwriting the original duration value. 

### All Submissions:

* [x] I have read the code of conduct.
* [x] I am submitting to the correct base branch

### Changes that modify the db structure

N/A - no db changes.

### New features

N/A - this is a bug fix.